### PR TITLE
Null Pointer Exception replaced with a better warning

### DIFF
--- a/src/main/java/uk/ac/ebi/ena/sra/cram/Utils.java
+++ b/src/main/java/uk/ac/ebi/ena/sra/cram/Utils.java
@@ -411,6 +411,9 @@ public class Utils {
 			else
 				rs = getReferenceSequenceOrNull(rsFile, "chr" + name);
 		}
+        if (rs == null) {
+            return null;
+        }
 
 		if (len < 1)
 			return rs.getBases();


### PR DESCRIPTION
If a chromosome is not found in the reference fasta, a warning is produced instead of a Null pointer exception.
